### PR TITLE
Add support for the FT4232h

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ let mut gpio = ftdi.ad6();
 ## Limitations
 
 * Limited trait support: SPI, I2C, Delay, and OutputPin traits are implemented.
-* Limited device support: FT232H.
+* Limited device support: FT232H, FT4232H.
 
 [embedded-hal]: https://crates.io/crates/embedded-hal
 [ftdi-embedded-hal]: https://github.com/geomatsi/ftdi-embedded-hal


### PR DESCRIPTION
Note, this is a breaking change, since it adds type parameters to structs such as I2c. I don't have a 4232h (although I'll get getting one in about a month). I tested this change with an ft2232 making an i2c request