### PR TITLE
call close() on Drop

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -9,7 +9,7 @@ use std::{cell::RefCell, sync::Mutex};
 /// [`FtHal::ad0`]: crate::FtHal::ad0
 /// [`FtHal::ad7`]: crate::FtHal::ad7
 #[derive(Debug)]
-pub struct OutputPin<'a, Device> {
+pub struct OutputPin<'a, Device: FtdiCommon> {
     /// Parent FTDI device.
     mtx: &'a Mutex<RefCell<FtInner<Device>>>,
     /// GPIO pin index.  0-7 for the FT232H.
@@ -41,9 +41,9 @@ impl<'a, Device: FtdiCommon> OutputPin<'a, Device> {
     }
 }
 
-impl<'a, Device> OutputPin<'a, Device> {
+impl<'a, Device: FtdiCommon> OutputPin<'a, Device> {
     /// Convert the GPIO pin index to a pin mask
-    pub(crate) const fn mask(&self) -> u8 {
+    pub(crate) fn mask(&self) -> u8 {
         1 << self.idx
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -42,7 +42,7 @@ impl Error for I2cError {}
 ///
 /// [`FtHal::i2c`]: crate::FtHal::i2c
 #[derive(Debug)]
-pub struct I2c<'a, Device> {
+pub struct I2c<'a, Device: FtdiCommon> {
     /// Parent FTDI device.
     mtx: &'a Mutex<RefCell<FtInner<Device>>>,
     /// Length of the start, repeated start, and stop conditions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ use libftd2xx::{
     DeviceTypeError, Ft2232h, Ft232h, Ft4232h, Ftdi, FtdiCommon, FtdiMpsse, MpsseSettings,
     TimeoutError,
 };
+use std::ops::Drop;
 use std::convert::TryFrom;
 use std::{cell::RefCell, convert::TryInto, sync::Mutex, time::Duration};
 
@@ -117,7 +118,7 @@ impl std::fmt::Display for PinUse {
 }
 
 #[derive(Debug)]
-struct FtInner<Device> {
+struct FtInner<Device: FtdiCommon> {
     /// FTDI device.
     ft: Device,
     /// GPIO direction.
@@ -126,6 +127,12 @@ struct FtInner<Device> {
     value: u8,
     /// Pin allocation.
     pins: [Option<PinUse>; 8],
+}
+
+impl<Device: FtdiCommon> Drop for FtInner<Device> {
+    fn drop(&mut self) {
+        self.ft.close().unwrap();
+    }
 }
 
 impl<Device: FtdiCommon> FtInner<Device> {
@@ -180,7 +187,7 @@ pub type Ft4232hHal<T> = FtHal<Ft4232h, T>;
 
 /// FTxxx device.
 #[derive(Debug)]
-pub struct FtHal<Device, INITIALIZED> {
+pub struct FtHal<Device: FtdiCommon, INITIALIZED> {
     #[allow(dead_code)]
     init: INITIALIZED,
     mtx: Mutex<RefCell<FtInner<Device>>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,8 @@ use libftd2xx::{
     DeviceTypeError, Ft2232h, Ft232h, Ft4232h, Ftdi, FtdiCommon, FtdiMpsse, MpsseSettings,
     TimeoutError,
 };
-use std::ops::Drop;
 use std::convert::TryFrom;
+use std::ops::Drop;
 use std::{cell::RefCell, convert::TryInto, sync::Mutex, time::Duration};
 
 /// State tracker for each pin on the FTDI chip.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ struct FtInner<Device: FtdiCommon> {
 
 impl<Device: FtdiCommon> Drop for FtInner<Device> {
     fn drop(&mut self) {
-        self.ft.close().unwrap();
+        self.ft.close().ok();
     }
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -9,7 +9,7 @@ use std::{cell::RefCell, sync::Mutex};
 ///
 /// [`FtHal::spi`]: crate::FtHal::spi
 #[derive(Debug)]
-pub struct Spi<'a, Device> {
+pub struct Spi<'a, Device: FtdiCommon> {
     /// Parent FTDI device.
     mtx: &'a Mutex<RefCell<FtInner<Device>>>,
     /// MPSSE command used to clock data in and out simultaneously.


### PR DESCRIPTION
If there is a failure on init(), there is no way to recover unless you call close() on the underlying device struct.