### PR TITLE
RFC: move mpsse helpers to the separate ftdi-mpsse crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ branch = "common-ftdimpsse"
 
 [dev-dependencies]
 version-sync = "~0.9.2"
+eeprom24x = "0.3.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ static = ["libftd2xx/static"]
 [dependencies]
 nb = "^1"
 embedded-hal = "~0.2.4"
-libftd2xx = "~0.31.0"
+#libftd2xx = "~0.31.0"
+
+[dependencies.libftd2xx]
+git = "https://github.com/geomatsi/libftd2xx-rs.git"
+branch = "common-ftdimpsse"
 
 [dev-dependencies]
 version-sync = "~0.9.2"

--- a/examples/eeprom24x.rs
+++ b/examples/eeprom24x.rs
@@ -1,0 +1,27 @@
+//! This example writes to and reads from the 24x serial EEPROM
+
+use eeprom24x::Eeprom24x;
+use eeprom24x::SlaveAddr;
+use ftd2xx_embedded_hal as hal;
+use std::thread::sleep;
+use std::time::Duration;
+
+fn main() {
+    let ftdi = hal::Ft232hHal::new()
+        .expect("Failed to open FT232H device")
+        .init_default()
+        .expect("Failed to initialize MPSSE");
+
+    let i2c = ftdi.i2c().expect("Failed to initialize I2C");
+    let mut eeprom = Eeprom24x::new_24x04(i2c, SlaveAddr::default());
+    let delay = Duration::from_millis(5);
+    let byte_w = 0xe5;
+    let addr = 0x0;
+
+    eeprom.write_byte(addr, byte_w).unwrap();
+    sleep(delay);
+
+    let byte_r = eeprom.read_byte(addr).unwrap();
+    assert_eq!(byte_w, byte_r);
+    println!("read and write byte: {:#x}", byte_r);
+}


### PR DESCRIPTION
Hi @newAM 

[Pull-request](https://github.com/newAM/libftd2xx-rs/pull/48) for ```libftd2xx-rs``` proposes to move all the FTDI MPSSE definitions and helpers into a separate crate. This accompanying PR adapts ftd2xx-embedded-hal to the proposed changes:
* add ftdi-mpsse crate to dependencies
* access mpsse helpers via new crate
* update code in comments

Besides, one more example is added for testing purposes.

Regards,
Sergey